### PR TITLE
Add cstdlib header in canalib.h

### DIFF
--- a/libs/include/canalib.h
+++ b/libs/include/canalib.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <utility>
 #include <cmath>
+#include <cstdlib>
 
 namespace cana
 {


### PR DESCRIPTION
Interesting. It requires cstdlib on my computer to build.